### PR TITLE
Remove Whitenoise from requirements/base.txt

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,8 +7,6 @@ celery==5.2.3
 django-celery-results==2.2.0
 django-celery-beat==2.2.1
 
-whitenoise==5.3.0
-
 django-filter==21.1
 django-cors-headers==3.11.0
 django-extensions==3.1.5


### PR DESCRIPTION
Excellent guide, it really helped me a lot structuring my own Django projects!

I have only one objection for the requirements/base.txt file.
Whitenoise is referenced in production requirements as well. I guess that it should not be included in the base requirements file.