### PR TITLE
DX: Django debug toolbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@
   * [Reading list](#reading-list)
 - [Example List API](#example-list-api)
 - [File uploads](#file-uploads)
-- [Helpful commands for local development without docker-compose](#helpful-commands-for-local-development-without-docker-compose)
-- [Helpful commands for local development with docker-compose](#helpful-commands-for-local-development-with-docker-compose)
+- [Helpful commands for local development without `docker compose`](#helpful-commands-for-local-development-without-docker-compose)
+- [Helpful commands for local development with `docker compose`](#helpful-commands-for-local-development-with-docker-compose)
 - [Deployment](#deployment)
   * [Heroku](#heroku)
   * [Render](#render)
@@ -46,7 +46,7 @@ The structure is inspired by [cookiecutter-django](https://github.com/pydanny/co
 Few important things:
 
 - Linux / Ubuntu is our primary OS and things are tested for that.
-- It's dockerized for local development with `docker-compose`.
+- It's dockerized for local development with `docker compose`.
 - It uses Postgres as the primary database.
 - It comes with [`whitenoise`](http://whitenoise.evans.io/en/stable/) setup, even for local development.
 - It comes with [`mypy`](https://mypy.readthedocs.io/en/stable/) configured, using both <https://github.com/typeddjango/django-stubs> and <https://github.com/typeddjango/djangorestframework-stubs/>
@@ -56,6 +56,7 @@ Few important things:
 - It comes with GitHub Actions support, [based on that article](https://hacksoft.io/github-actions-in-action-setting-up-django-and-postgres/)
 - It can be easily deployed to Heroku, Render or AWS ECS.
 - It comes with an example list API, that uses [`django-filter`](https://django-filter.readthedocs.io/en/stable/) for filtering & pagination from DRF.
+- It comes with setup for [Django Debug Toolbar](https://django-debug-toolbar.readthedocs.io/en/latest/)
 - It comes with examples for writing tests with fakes & factories, based on the following articles - <https://www.hacksoft.io/blog/improve-your-tests-django-fakes-and-factories>, <https://www.hacksoft.io/blog/improve-your-tests-django-fakes-and-factories-advanced-usage>
 
 ## General API Stuff
@@ -249,7 +250,7 @@ Currently, the following is supported:
 
 Feel free to use this as the basis of your file upload needs.
 
-## Helpful commands for local development without docker-compose
+## Helpful commands for local development without `docker compose`
 
 To create Postgres database:
 
@@ -275,24 +276,24 @@ To start Celery Beat:
 celery -A styleguide_example.tasks beat -l info --scheduler django_celery_beat.schedulers:DatabaseScheduler
 ```
 
-## Helpful commands for local development with docker-compose
+## Helpful commands for local development with `docker compose`
 
 To build and run everything
 
 ```
-docker-compose up
+docker compose up
 ```
 
 To run migrations
 
 ```
-docker-compose run django python manage.py migrate
+docker compose run django python manage.py migrate
 ```
 
 To shell
 
 ```
-docker-compose run django python manage.py shell
+docker compose run django python manage.py shell
 ```
 
 ## Deployment

--- a/config/django/base.py
+++ b/config/django/base.py
@@ -23,7 +23,7 @@ env.read_env(os.path.join(BASE_DIR, ".env"))
 SECRET_KEY = "=ug_ucl@yi6^mrcjyz%(u0%&g2adt#bz3@yos%#@*t#t!ypx=a"
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = env.bool("DJANGO_DEBUG", default=True)
 
 ALLOWED_HOSTS = ["*"]
 
@@ -181,3 +181,8 @@ from config.settings.files_and_storages import *  # noqa
 from config.settings.jwt import *  # noqa
 from config.settings.sentry import *  # noqa
 from config.settings.sessions import *  # noqa
+
+from config.settings.debug_toolbar.settings import *  # noqa
+from config.settings.debug_toolbar.setup import DebugToolbarSetup  # noqa
+
+INSTALLED_APPS, MIDDLEWARE = DebugToolbarSetup.do_settings(INSTALLED_APPS, MIDDLEWARE)

--- a/config/django/test.py
+++ b/config/django/test.py
@@ -1,3 +1,12 @@
+import os
+
+# This is extremely "eye-poking",
+# but we need it, if we want to ignore the debug toolbar in tests
+# This is needed because of the way we setup Django Debug Toolbar.
+# Since we import base settings, the entire setup will be done, before we have any chance to change it.
+# A different way of approaching this would be to have a separate set of env variables for tests.
+os.environ.setdefault("DEBUG_TOOLBAR_ENABLED", "False")
+
 from .base import *  # noqa
 
 # Based on https://www.hacksoft.io/blog/optimize-django-build-to-run-faster-on-github-actions

--- a/config/settings/debug_toolbar/settings.py
+++ b/config/settings/debug_toolbar/settings.py
@@ -1,0 +1,4 @@
+from config.env import env
+
+DEBUG_TOOLBAR_ENABLED = env.bool("DEBUG_TOOLBAR_ENABLED", default=True)
+DEBUG_TOOLBAR_CONFIG = {"SHOW_TOOLBAR_CALLBACK": "config.settings.debug_toolbar.setup.show_toolbar"}

--- a/config/settings/debug_toolbar/settings.py
+++ b/config/settings/debug_toolbar/settings.py
@@ -2,3 +2,6 @@ from config.env import env
 
 DEBUG_TOOLBAR_ENABLED = env.bool("DEBUG_TOOLBAR_ENABLED", default=True)
 DEBUG_TOOLBAR_CONFIG = {"SHOW_TOOLBAR_CALLBACK": "config.settings.debug_toolbar.setup.show_toolbar"}
+
+# You can place additional settings below
+# https://django-debug-toolbar.readthedocs.io/en/latest/configuration.html

--- a/config/settings/debug_toolbar/setup.py
+++ b/config/settings/debug_toolbar/setup.py
@@ -1,0 +1,82 @@
+import logging
+
+from django.urls import include, path
+
+logger = logging.getLogger("configuration")
+
+
+def show_toolbar(*args, **kwargs) -> bool:
+    """
+    The general idea is the following:
+
+    1. We show the toolbar if we have it installed & we have it configured to be shown.
+        - This opens up the option to move the dependency as a local one, if one chooses to do so.
+    2. This function acts as the single source of truth of that.
+        - No additional checks elsewhere are required.
+
+    This means we can have the following options possible:
+
+    - Show on a production environments.
+    - Exclude the entire dependency from production environments.
+    - Have the flexibility to control the debug toolbar via a single Django setting.
+
+    Additionally, we don't want to deal with the INTERNAL_IPS thing.
+    """
+    from .settings import DEBUG_TOOLBAR_ENABLED
+
+    if not DEBUG_TOOLBAR_ENABLED:
+        return False
+
+    try:
+        import debug_toolbar  # noqa
+    except ImportError:
+        logger.info("No installation found for: django_debug_toolbar")
+        return False
+
+    return True
+
+
+class DebugToolbarSetup:
+    """
+    We use a class, just for namespacing convenience.
+    """
+
+    @staticmethod
+    def do_settings(INSTALLED_APPS, MIDDLEWARE, middleware_position=None):
+        _show_toolbar: bool = show_toolbar()
+        logger.info(f"Django Debug Toolbar in use: {_show_toolbar}")
+
+        if not _show_toolbar:
+            return INSTALLED_APPS, MIDDLEWARE
+
+        INSTALLED_APPS = INSTALLED_APPS + ["debug_toolbar"]
+
+        # In order to deal with that:
+        # https://django-debug-toolbar.readthedocs.io/en/latest/installation.html#add-the-middleware
+        # The order of MIDDLEWARE is important.
+        # You should include the Debug Toolbar middleware as early as possible in the list.
+        # However, it must come after any other middleware that encodes the response’s content, such as GZipMiddleware.
+        # We support inserting the middleware at an arbitrary position in the list.
+        # If position is not specified, we will just include it at the end of the list.
+
+        debug_toolbar_middleware = "debug_toolbar.middleware.DebugToolbarMiddleware"
+
+        if middleware_position is None:
+            MIDDLEWARE = MIDDLEWARE + [debug_toolbar_middleware]
+        else:
+            # Grab a new copy of the list, since insert mutates the internal structure
+            _middleware = MIDDLEWARE[::]
+            _middleware.insert(middleware_position, debug_toolbar_middleware)
+
+            MIDDLEWARE = _middleware
+
+        return INSTALLED_APPS, MIDDLEWARE
+
+    @staticmethod
+    def do_urls(urlpatterns):
+        if not show_toolbar():
+            return urlpatterns
+
+        import debug_toolbar  # noqa
+
+        return urlpatterns + [path("__debug__/", include(debug_toolbar.urls))]

--- a/config/urls.py
+++ b/config/urls.py
@@ -22,3 +22,7 @@ urlpatterns = [
     path("admin/", admin.site.urls),
     path("api/", include(("styleguide_example.api.urls", "api"))),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+
+from config.settings.debug_toolbar.setup import DebugToolbarSetup  # noqa
+
+urlpatterns = DebugToolbarSetup.do_urls(urlpatterns)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,3 +3,12 @@ line-length = 120
 # By default, `black` will ignore skip configuration when paths are explicitly provided.
 # In order for `pre-commit` to respect this configuration, `force-exclude` needs to be explicitly set.
 force-exclude = 'migrations'
+
+[tool.isort]
+# https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#isort
+profile = "black"
+# By default, `isort` will ignore skip configuration when paths are explicitly provided.
+# In order for `pre-commit` to respect this configuration, `filter_files` needs to be set to true.
+# https://jugmac00.github.io/blog/isort-and-pre-commit-a-friendship-with-obstacles/
+filter_files = true
+skip_glob = ["*/migrations/*", "config/*"]

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -9,6 +9,8 @@ Faker==15.1.1
 ipdb==0.13.9
 ipython==8.6.0
 
+django-debug-toolbar==3.8.1
+
 mypy==0.991
 
 django-stubs==1.14.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,12 +6,3 @@ exclude =
     .git,
     __pycache__,
     */migrations/*
-
-[isort]
-# https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#isort
-profile = black
-# By default, `isort` will ignore skip configuration when paths are explicitly provided.
-# In order for `pre-commit` to respect this configuration, `filter_files` needs to be set to true.
-# https://jugmac00.github.io/blog/isort-and-pre-commit-a-friendship-with-obstacles/
-filter_files = true
-skip_glob = */migrations/*


### PR DESCRIPTION
The general idea is the following:

1. We show the toolbar if we have it installed & we have it configured to be shown.
    - This opens up the option to move the dependency as a local one, if one chooses to do so.
1. This function acts as the single source of truth of that.
    - No additional checks elsewhere are required.

This means we can have the following options possible:

- Show on a production environments.
- Exclude the entire dependency from production environments.
- Have the flexibility to control the debug toolbar via a single Django setting.
 
Additionally, we don't want to deal with the `INTERNAL_IPS` thing.