### PR TITLE
Migrate from docker-compose to docker compose

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -6,17 +6,17 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build docker
-        run: docker-compose build
+        run: docker compose build
       - name: Run isort
-        run: docker-compose run django isort styleguide_example/ --check
+        run: docker compose run django isort styleguide_example/ --check
       - name: Run black
-        run: docker-compose run django black styleguide_example/ --check
+        run: docker compose run django black styleguide_example/ --check
       - name: Run flake8
-        run: docker-compose run django flake8
+        run: docker compose run django flake8
       - name: Run mypy
-        run: docker-compose run django mypy --config mypy.ini styleguide_example/
+        run: docker compose run django mypy --config mypy.ini styleguide_example/
       - name: Run tests
-        run: docker-compose run django py.test
+        run: docker compose run django py.test
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
`docker-compose` is now deprecated so we migrate to `docker compose` 

