### PR TITLE
Updated command to run pytest

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Type check
         run: mypy --config mypy.ini styleguide_example/
       - name: Run tests
-        run: py.test
+        run: pytest
 
   deploy_to_heroku:
     runs-on: ubuntu-latest


### PR DESCRIPTION
pytest is the recommended way to run pytest since version 3.0, the old command of py.test may be deprecated in the future. See here: https://github.com/pytest-dev/pytest/issues/1629