### PR TITLE
Add Admin template page branch processing according to custom_admin s…

### DIFF
--- a/styleguide_example/templates/admin/base_site.html
+++ b/styleguide_example/templates/admin/base_site.html
@@ -2,7 +2,9 @@
 
 {% block userlinks %}
   {% if user.is_active and user.is_staff %}
-    <a href="{% url "admin:setup-2fa" %}"> Setup 2FA </a> /
+    {% if "styleguide_example.custom_admin" in INSTALLED_APPS %}
+      <a href="{% url "admin:setup-2fa" %}"> Setup 2FA </a> /
+    {% endif %}
   {% endif %}
 
   {{ block.super }}


### PR DESCRIPTION
If you run a project after forking or cloning, you will not be able to access the administrator page.

1. docker-compose up
2. docker-compose run django migrate
3. docker-compose run django createsuperuser
4. access admin page -> X

Because django.contrib.admin is the default setting.

Therefore, the configuration of the administrator page should be different according to the INSTALLED_APP setting.