### PR TITLE
Minor fix: Rename celery entrypoint scripts

### DIFF
--- a/docker/beats_entrypoint.sh
+++ b/docker/beats_entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 echo "--> Starting beats process"
-celery -A styleguide_example.tasks worker -l info --without-gossip --without-mingle --without-heartbeat
+celery -A styleguide_example.tasks beat -l info --scheduler django_celery_beat.schedulers:DatabaseScheduler

--- a/docker/celery_entrypoint.sh
+++ b/docker/celery_entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 echo "--> Starting celery process"
-celery -A styleguide_example.tasks beat -l info --scheduler django_celery_beat.schedulers:DatabaseScheduler
+celery -A styleguide_example.tasks worker -l info --without-gossip --without-mingle --without-heartbeat


### PR DESCRIPTION
Looks like the beats and worker process script have their commands swapped. I swapped them back.